### PR TITLE
Update out of date dependencies

### DIFF
--- a/lib/vcr.js
+++ b/lib/vcr.js
@@ -1,5 +1,5 @@
-var defaults    = require('lodash-node/modern/object/defaults');
-var assign      = require('lodash-node/modern/object/assign');
+var defaults    = require('lodash/defaults');
+var assign      = require('lodash/assign');
 var useCassette = require('./use-cassette');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "lodash-node": "^3.1.0",
     "mkdirp": "^0.5.0",
-    "nock": "^0.59.0",
+    "nock": "^8.0.0",
     "rsvp": "^3.0.16"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "rsvp": "^3.0.16"
   },
   "devDependencies": {
-    "express": "^3.4.8",
+    "express": "^4.13.4",
     "mocha": "^2.0.1",
     "request": "~2.72.0"
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   "devDependencies": {
     "express": "^3.4.8",
     "mocha": "^2.0.1",
-    "request": "~2.34.0"
+    "request": "~2.72.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "express": "^4.13.4",
-    "mocha": "^2.0.1",
+    "mocha": "^2.5.1",
     "request": "~2.72.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/poetic/nock-vcr-recorder",
   "dependencies": {
-    "lodash-node": "^3.1.0",
+    "lodash": "^4.13.1",
     "mkdirp": "^0.5.0",
     "nock": "^8.0.0",
     "rsvp": "^3.0.16"


### PR DESCRIPTION
I ran into an issue trying to use nock-vcr-recorder because the version of nock that it uses is 16 months old. Thanks to your test suite I was able to go ahead and update all the other dependencies as well.

If you could publish a new release with these I'd be very appreciative.
