### PR TITLE
Switch from RSVP to Bluebird for Promises

### DIFF
--- a/lib/use-cassette.js
+++ b/lib/use-cassette.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var RSVP      = require('rsvp');
+var Promise   = require('bluebird');
 var nock      = require('nock');
 var path      = require('path');
 var fs        = require('fs');
-var mkdirp    = RSVP.denodeify(require('mkdirp'));
-var writeFile = RSVP.denodeify(fs.writeFile);
+var mkdirp    = Promise.promisify(require('mkdirp'));
+var writeFile = Promise.promisify(fs.writeFile);
 
 module.exports = function(cassette, options, testFn) {
   var cassettePath = path.resolve(
@@ -26,11 +26,11 @@ module.exports = function(cassette, options, testFn) {
         return afterTest(cassettePath, options);
       }
 
-      return RSVP.reject(err);
+      return Promise.reject(err);
     });
   }
 
-  return RSVP.resolve(testRun);
+  return Promise.resolve(testRun);
 };
 
 function beforeTest(cassettePath, options) {
@@ -61,7 +61,7 @@ function afterTest(cassettePath, options) {
     });
   }
 
-  return RSVP.resolve();
+  return Promise.resolve();
 }
 
 function nockReset() {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "homepage": "https://github.com/poetic/nock-vcr-recorder",
   "dependencies": {
+    "bluebird": "^3.4.0",
     "lodash-node": "^3.1.0",
     "mkdirp": "^0.5.0",
-    "nock": "^0.59.0",
-    "rsvp": "^3.0.16"
+    "nock": "^0.59.0"
   },
   "devDependencies": {
     "express": "^3.4.8",

--- a/test/config-test.js
+++ b/test/config-test.js
@@ -1,6 +1,6 @@
-var RSVP   = require('rsvp');
-var assert = require('assert');
-var vcr    = require('../lib/vcr');
+var Promise = require('bluebird');
+var assert  = require('assert');
+var vcr     = require('../lib/vcr');
 
 describe('vcr - config', function() {
   beforeEach(function() {
@@ -29,7 +29,7 @@ describe('vcr - config', function() {
     return vcr.useCassette('test config', {
       excludeScope: ['github.com']
     }, function() {
-      return RSVP.resolve();
+      return Promise.resolve();
     }).then(function() {
       assert.deepEqual(vcr._config, {
         excludeScope: ['localhost', '127.0.0.1', '0.0.0.0'],

--- a/test/use-cassette-test.js
+++ b/test/use-cassette-test.js
@@ -1,9 +1,9 @@
 var path    = require('path');
 var fs      = require('fs');
-var RSVP    = require('rsvp');
+var Promise = require('bluebird');
 var mkdirp  = require('mkdirp');
 var nock    = require('nock');
-var request = RSVP.denodeify(require('request'));
+var request = Promise.promisify(require('request'));
 var app     = require('./app');
 var vcr     = require('../lib/vcr');
 var assert  = require('assert');
@@ -11,7 +11,7 @@ var assert  = require('assert');
 describe('vcr.useCassette - callback promises', function() {
   it('resolves', function() {
     return vcr.useCassette('record handles resovled promises', function() {
-      return RSVP.resolve();
+      return Promise.resolve();
     }).then(function() {
       assert.ok(true, 'returned a promise');
     }, function() {
@@ -21,7 +21,7 @@ describe('vcr.useCassette - callback promises', function() {
 
   it('rejects', function() {
     return vcr.useCassette('record handles rejected promises', function() {
-      return RSVP.reject();
+      return Promise.reject();
     }).then(function() {
       assert.ok(false, 'returned an error');
     }, function() {
@@ -145,7 +145,7 @@ describe('vcr.useCassette - requests - recording', function() {
         writeOnFailure: false
       }, function() {
         return request('http://localhost:4006/test').then(function() {
-          return RSVP.reject('mock failed test');
+          return Promise.reject('mock failed test');
         });
       }).then(null, function() {
         assertNotCassette('doesnt save when test fails');
@@ -157,7 +157,7 @@ describe('vcr.useCassette - requests - recording', function() {
         writeOnFailure: true
       }, function() {
         return request('http://localhost:4006/test').then(function() {
-          return RSVP.reject('mock failed test');
+          return Promise.reject('mock failed test');
         });
       }).then(null, function() {
         assertCassette('saves when test fails');


### PR DESCRIPTION
Bluebird has become something of a defacto Promise library in the node community because of its speed and support history. Consequently many projects already have Bluebird installed, so having VCR use it instead of RSVP would reduce the number of dependencies to download.

These are just my opinions, however, so I won't be offended if you reject this PR :)
