### PR TITLE
Update nock to 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "lodash-node": "^3.1.0",
     "mkdirp": "^0.5.0",
-    "nock": "^0.59.0",
+    "nock": "^8.0.0",
     "rsvp": "^3.0.16"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the nock dependency to the latest version. The test suite passes with the updated version.

I have found that when using nock-vcr-recorder, with nock 0.59.0, doesn't work well with [axios](https://www.npmjs.com/package/axios). Specifically, when requesting a JSON document and recording a cassette for the first time, `response.data` will be the empty string, rather than a JSON object. After updating nock-vcr-recorder's nock dependency to 8.0.0, I tried the same thing again, and the response data came through fine, and the cassette was recorded successfully.
